### PR TITLE
Use regex for device name to match all Launchpad devices

### DIFF
--- a/lib/launchpad/device.rb
+++ b/lib/launchpad/device.rb
@@ -338,8 +338,8 @@ module Launchpad
       logger.debug "creating #{device_type} with #{opts.inspect}, choosing from portmidi devices #{devices.inspect}"
       id = opts[:id]
       if id.nil?
-        name = opts[:name] || 'Launchpad'
-        device = devices.select {|device| device.name == name}.first
+        name = opts[:name] || /Launchpad.*/
+        device = devices.select {|device| device.name =~ name}.first
         id = device.device_id unless device.nil?
       end
       if id.nil?


### PR DESCRIPTION
Hey great project, it's awesome to be able to finally use the launchpad from ruby! (with one change!)

The hardcoded Launchpad device name causes the following error if one attempts to use this library to interface with another Launchpad model, such as the mini (which I own):

```
.../launchpad.rb/lib/launchpad/device.rb:350:in `create_device!': MIDI device  doesn't exist (Launchpad::NoSuchDeviceError)
	from .../launchpad.rb/lib/launchpad/device.rb:102:in `initialize'
	from ./examples/colors.rb:3:in `new'
	from ./examples/colors.rb:3:in `<main>'
```

This Mini's Portmidi output device is as follows:

```
> Portmidi.input_devices
=> [#<Portmidi::Device:1 @name="Midi Through Port-0", @type=:input>, #<Portmidi::Device:3 @name="Launchpad Mini MIDI 1", @type=:input>]
```

By applying the following fix, I was able to get it working.