### PR TITLE
Support LaunchPad MK2

### DIFF
--- a/lib/launchpad/device.rb
+++ b/lib/launchpad/device.rb
@@ -63,6 +63,11 @@ module Launchpad
       :scene8   => SceneButton::SCENE8
     }.freeze
 
+    SUPPORTED_LAUNCHPADS = {
+      'Launchpad' => {},
+      'Launchpad MK2' => {},
+    }
+
     # Initializes the launchpad device. When output capabilities are requested,
     # the launchpad will be reset.
     # 
@@ -338,8 +343,14 @@ module Launchpad
       logger.debug "creating #{device_type} with #{opts.inspect}, choosing from portmidi devices #{devices.inspect}"
       id = opts[:id]
       if id.nil?
-        name = opts[:name] || 'Launchpad'
-        device = devices.select {|device| device.name == name}.first
+        name = opts[:name]
+        device = devices.find do |device|
+          if name
+            device.name == name
+          else
+            SUPPORTED_LAUNCHPADS[device.name]
+          end
+        end
         id = device.device_id unless device.nil?
       end
       if id.nil?

--- a/lib/launchpad/device_layouts.rb
+++ b/lib/launchpad/device_layouts.rb
@@ -1,0 +1,31 @@
+module Launchpad
+  module DeviceLayouts
+    Launchpad = {
+      MIN_X: 0,
+      MIN_Y: 0,
+      MAX_X: 7,
+      MAX_Y: 7,
+      GRID_OFFSET: 0,
+      GRID_STRIDE: 16,
+    }.freeze
+
+    LaunchpadMK2 = {
+      BUTTON_LOCATIONS: {
+        record_arm: [8, 0],
+        solo: [8, 1],
+        mute: [8, 2],
+        stop: [8, 3],
+        send_a: [8, 4],
+        send_b: [8, 5],
+        pan: [8, 6],
+        volume: [8, 7],
+      },
+      MIN_X: 0,
+      MIN_Y: 0,
+      MAX_X: 8,
+      MAX_Y: 7,
+      GRID_OFFSET: 11,
+      GRID_STRIDE: 10,
+    }.freeze
+  end
+end

--- a/lib/launchpad/errors.rb
+++ b/lib/launchpad/errors.rb
@@ -5,6 +5,9 @@ module Launchpad
   
   # Error raised when the MIDI device specified doesn't exist.
   class NoSuchDeviceError < LaunchpadError; end
+
+  # Error raised when unable to determine a board layout to use.
+  class UnknownLayout < LaunchpadError; end
   
   # Error raised when the MIDI device specified is busy.
   class DeviceBusyError < LaunchpadError; end


### PR DESCRIPTION
Hi there!

I recently purchased a `LaunchPad Mk2` and ran into quite a few issues trying to use this library. I was able to fix many of the issues locally, and would appreciate your feedback on this PR.

Big changes are:

* Accept a default name of `Launchpad` of `Launchpad MK2`
* Abstract out the device layout (likely needs to be renamed to avoid confusion between the Launchpad's "layout")
* Adjust grid bounds + stride, and errors (the Mk2 for some reason uses different grid offsets)
* Adjust color logic

I also made some stylistic changes to avoid nesting `ifs` where I thought it could be prettier. Happy to revert those changes as they don't fit the style of the codebase.

Creating this as a draft because I don't want to assume you will want these changes in your repo. Just offering to share back my changes. :)

Also, this is in a "i just got it working" state, so I wouldn't be surprised if I've made pervasive mistakes in this implementation.